### PR TITLE
Fix nested entity references

### DIFF
--- a/src/__tests__/entityReference.spec.ts
+++ b/src/__tests__/entityReference.spec.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest"
-import { z } from "zod"
-import { createVersionedEntity, defineVersion, entityReference } from "../index.js"
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  createVersionedEntity,
+  defineVersion,
+  entityReference,
+} from "../index.js";
 
 const v1_schema = z.object({
   name: z.string(),
@@ -11,9 +15,9 @@ const v1_schema = z.object({
       value: z.string(),
     })
   ),
-})
+});
 
-type V1 = z.infer<typeof v1_schema>
+type V1 = z.infer<typeof v1_schema>;
 
 const v2_schema = z.object({
   name: z.string(),
@@ -31,14 +35,14 @@ const v2_schema = z.object({
       }),
     ])
   ),
-})
+});
 
-type V2 = z.infer<typeof v2_schema>
+type V2 = z.infer<typeof v2_schema>;
 
 const test_V1_version = defineVersion({
   initial: true,
   schema: v1_schema,
-})
+});
 
 const test_V2_version = defineVersion({
   initial: false,
@@ -52,11 +56,11 @@ const test_V2_version = defineVersion({
         value: v.value,
         masked: false,
       })),
-    }
+    };
 
-    return x
+    return x;
   },
-})
+});
 
 const testEntity = createVersionedEntity({
   latestVersion: 2,
@@ -66,24 +70,24 @@ const testEntity = createVersionedEntity({
   },
   getVersion(data) {
     if (typeof data !== "object" || data === null) {
-      return null
+      return null;
     }
 
     // @ts-expect-error - TypeScript cannot understand that the above check will ensure that data is an object
-    const ver = data["v"]
+    const ver = data["v"];
 
     if (typeof ver !== "number") {
-      return null
+      return null;
     }
 
-    return ver
+    return ver;
   },
-})
+});
 
 const connectedSchema = z.object({
   v: z.literal(1),
   testEntity: entityReference(testEntity),
-})
+});
 
 describe("entityReference", () => {
   it("should validate the entity as valid if valid latest schema", () => {
@@ -100,10 +104,10 @@ describe("entityReference", () => {
           },
         ],
       },
-    })
+    });
 
-    expect(result.success).toEqual(true)
-  })
+    expect(result.success).toEqual(true);
+  });
 
   it("should not change the entity if validated as valid with latest schema", () => {
     const result = connectedSchema.safeParse({
@@ -119,11 +123,11 @@ describe("entityReference", () => {
           },
         ],
       },
-    })
+    });
 
-    expect(result.success).toEqual(true)
+    expect(result.success).toEqual(true);
 
-    if (!result.success) throw new Error("this should not be called")
+    if (!result.success) throw new Error("this should not be called");
 
     expect(result.data.testEntity).toEqual({
       v: 2,
@@ -135,8 +139,8 @@ describe("entityReference", () => {
           masked: false,
         },
       ],
-    })
-  })
+    });
+  });
 
   it("should validate the entity as valid if valid old schema", () => {
     const result = connectedSchema.safeParse({
@@ -151,10 +155,10 @@ describe("entityReference", () => {
           },
         ],
       },
-    })
+    });
 
-    expect(result.success).toEqual(true)
-  })
+    expect(result.success).toEqual(true);
+  });
 
   it("should transform the entity to the latest version if valid old schema", () => {
     const result = connectedSchema.safeParse({
@@ -169,11 +173,11 @@ describe("entityReference", () => {
           },
         ],
       },
-    })
+    });
 
-    expect(result.success).toEqual(true)
+    expect(result.success).toEqual(true);
 
-    if (!result.success) throw new Error("this should not be called")
+    if (!result.success) throw new Error("this should not be called");
 
     expect(result.data.testEntity).toEqual({
       v: 2,
@@ -185,20 +189,20 @@ describe("entityReference", () => {
           masked: false,
         },
       ],
-    })
-  })
-})
+    });
+  });
+});
 
-const migrate_child_v1 = z.object({ v: z.literal(1), a: z.number() })
-const migrate_child_v2 = z.object({ v: z.literal(2), b: z.number() })
+const migrate_child_v1 = z.object({ v: z.literal(1), a: z.number() });
+const migrate_child_v2 = z.object({ v: z.literal(2), b: z.number() });
 const migrateChildVersioned = createVersionedEntity({
   latestVersion: 2,
   getVersion(data) {
     if (typeof data !== "object" || data === null) {
-      return null
+      return null;
     }
     // @ts-expect-error
-    return data["v"]
+    return data["v"];
   },
   versionMap: {
     1: defineVersion({
@@ -208,33 +212,35 @@ const migrateChildVersioned = createVersionedEntity({
     2: defineVersion({
       initial: false,
       schema: migrate_child_v2,
-      up(old: z.infer<typeof migrate_child_v1>): z.infer<typeof migrate_child_v2> {
-        return { v: 2, b: old.a }
+      up(
+        old: z.infer<typeof migrate_child_v1>
+      ): z.infer<typeof migrate_child_v2> {
+        return { v: 2, b: old.a };
       },
     }),
   },
-})
-const migrateChildSchema = entityReference(migrateChildVersioned)
+});
+const migrateChildSchema = entityReference(migrateChildVersioned);
 
 const migrate_parent_v1 = z.object({
   v: z.literal(1),
   c: z.number(),
   child: migrateChildSchema,
-})
+});
 const migrate_parent_v2 = z.object({
   v: z.literal(2),
   d: z.number(),
   child: migrateChildSchema,
-})
+});
 
 const migrateParentVersioned = createVersionedEntity({
   latestVersion: 2,
   getVersion(data) {
     if (typeof data !== "object" || data === null) {
-      return null
+      return null;
     }
     // @ts-expect-error
-    return data["v"]
+    return data["v"];
   },
   versionMap: {
     1: defineVersion({
@@ -244,13 +250,15 @@ const migrateParentVersioned = createVersionedEntity({
     2: defineVersion({
       initial: false,
       schema: migrate_parent_v2,
-      up(old: z.infer<typeof migrate_parent_v1>): z.infer<typeof migrate_parent_v2> {
-        return { v: 2, d: old.c, child: old.child }
+      up(
+        old: z.infer<typeof migrate_parent_v1>
+      ): z.infer<typeof migrate_parent_v2> {
+        return { v: 2, d: old.c, child: old.child };
       },
     }),
   },
-})
-const migrateParentSchema = entityReference(migrateParentVersioned)
+});
+const migrateParentSchema = entityReference(migrateParentVersioned);
 
 describe("nested entityReference", () => {
   it("nest migrations should migrate to latest version", () => {
@@ -261,12 +269,12 @@ describe("nested entityReference", () => {
         v: 1,
         a: 8,
       },
-    })
-    console.log(result)
+    });
+    console.log(result);
 
-    expect(result.success).toBe(true)
+    expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({ v: 2, d: 4, child: { v: 2, b: 8 } })
+      expect(result.data).toEqual({ v: 2, d: 4, child: { v: 2, b: 8 } });
     }
-  })
-})
+  });
+});

--- a/src/__tests__/entityReference.spec.ts
+++ b/src/__tests__/entityReference.spec.ts
@@ -270,9 +270,9 @@ describe("nested entityReference", () => {
         a: 8,
       },
     });
-    console.log(result);
 
     expect(result.success).toBe(true);
+
     if (result.success) {
       expect(result.data).toEqual({ v: 2, d: 4, child: { v: 2, b: 8 } });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,6 @@ export class VersionedEntity<
       finalData = upDef.up(finalData)
     }
 
-    // @ts-expect-error - TypeScript cannot understand that the above loop will update finalData to the latest version
     return { type: "ok", value: finalData }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod"
 
 /**
  * Defines a version of a Verzod entity schema and how to upgrade from the previous version.
@@ -7,19 +7,19 @@ export type Version<NewScheme extends z.ZodType, OldScheme> = {
   /**
    * The schema for this version of the entity.
    */
-  schema: NewScheme;
+  schema: NewScheme
 } & (
   | {
       /**
        * Whether this version is the initial version of the entity.
        */
-      initial: true;
+      initial: true
     }
   | {
       /**
        * Whether this version is the initial version of the entity.
        */
-      initial: false;
+      initial: false
 
       /**
        * Migrate from the previous version of the schema
@@ -27,9 +27,9 @@ export type Version<NewScheme extends z.ZodType, OldScheme> = {
        *
        * @returns The data as in the new version of the schema
        */
-      up: (old: OldScheme) => z.infer<NewScheme>;
+      up: (old: OldScheme) => z.infer<NewScheme>
     }
-);
+)
 
 /**
  * A helper function to define a version of a Verzod entity schema
@@ -40,18 +40,15 @@ export type Version<NewScheme extends z.ZodType, OldScheme> = {
  * @param def The version definition
  */
 export const defineVersion = <NewScheme extends z.ZodType, OldScheme>(
-  def: Version<NewScheme, OldScheme>,
-) => def;
+  def: Version<NewScheme, OldScheme>
+) => def
 
 /**
  * Extracts the final type from a version definition
  */
-export type SchemaOf<T extends Version<any, any>> = T extends Version<
-  infer S,
-  any
->
+export type SchemaOf<T extends Version<any, any>> = T extends Version<infer S, any>
   ? z.infer<S>
-  : never;
+  : never
 
 /**
  * The definition of a result derived from parsing a Verzod entity.
@@ -59,44 +56,44 @@ export type SchemaOf<T extends Version<any, any>> = T extends Version<
 export type ParseResult<T> =
   | { type: "ok"; value: T }
   | {
-      type: "err";
+      type: "err"
       error:
         | {
             /**
              * The version of the data was not able to be determined by the entity definition.
              * Most probably the data is not a valid entity.
              */
-            type: "VER_CHECK_FAIL";
+            type: "VER_CHECK_FAIL"
           }
         | {
             /**
              * The version of the data as determined by the entity definition
              * is not a valid version as it is not defined in the entity's version map.
              */
-            type: "INVALID_VER";
+            type: "INVALID_VER"
           }
         | {
             /**
              * The data is of a valid version but does not pass
              * the schema validation for that version.
              */
-            type: "GIVEN_VER_VALIDATION_FAIL";
+            type: "GIVEN_VER_VALIDATION_FAIL"
 
             /**
              * The version of the data as determined by the entity definition.
              */
-            version: number;
+            version: number
 
             /**
              * The definition of the version of the data
              * corresponding to the determined version
              */
-            versionDef: Version<z.ZodType, unknown>;
+            versionDef: Version<z.ZodType, unknown>
 
             /**
              * The `ZodError` returned by the schema validation.
              */
-            error: z.ZodError;
+            error: z.ZodError
           }
         | {
             /**
@@ -109,12 +106,12 @@ export type ParseResult<T> =
              * then this error will be thrown when you try to parse a version 1 data,
              * as Verzod will try to migrate from 1 to 2 and then from 2 to 3.
              */
-            type: "BUG_NO_INTERMEDIATE_FOUND";
+            type: "BUG_NO_INTERMEDIATE_FOUND"
 
             /**
              * The version that is missing from the entity definition.
              */
-            missingVer: number;
+            missingVer: number
           }
         | {
             /**
@@ -123,19 +120,18 @@ export type ParseResult<T> =
              * has marked an intermediate version as initial and thus
              * does not have an `up` function to migrate from the previous version.
              */
-            type: "BUG_INTERMEDIATE_MARKED_INITIAL";
+            type: "BUG_INTERMEDIATE_MARKED_INITIAL"
 
             /**
              * The version that is marked as initial.
              */
-            ver: number;
-          };
-    };
+            ver: number
+          }
+    }
 
 export class VersionedEntity<
   LatestVer extends number,
-  M extends Record<LatestVer, Version<any, any>> &
-    Record<number, Version<any, any>>,
+  M extends Record<LatestVer, Version<any, any>> & Record<number, Version<any, any>>
 > {
   /**
    * @package
@@ -144,7 +140,7 @@ export class VersionedEntity<
   constructor(
     private versionMap: M,
     private latestVersion: LatestVer,
-    private getVersion: (data: unknown) => number | null,
+    private getVersion: (data: unknown) => number | null
   ) {}
 
   /**
@@ -153,15 +149,15 @@ export class VersionedEntity<
    * @returns Whether the given data is a valid entity of any version of the entity.
    */
   public is(data: unknown): data is SchemaOf<M[keyof M]> {
-    let ver = this.getVersion(data);
+    let ver = this.getVersion(data)
 
-    if (ver === null) return false;
+    if (ver === null) return false
 
-    const verDef = this.versionMap[ver];
+    const verDef = this.versionMap[ver]
 
-    if (!verDef) return false;
+    if (!verDef) return false
 
-    return verDef.schema.safeParse(data).success;
+    return verDef.schema.safeParse(data).success
   }
 
   /**
@@ -170,7 +166,7 @@ export class VersionedEntity<
    * @returns Whether the given data is a valid entity of the latest version of the entity.
    */
   public isLatest(data: unknown): data is SchemaOf<M[LatestVer]> {
-    return this.versionMap[this.latestVersion].schema.safeParse(data).success;
+    return this.versionMap[this.latestVersion].schema.safeParse(data).success
   }
 
   /**
@@ -179,19 +175,19 @@ export class VersionedEntity<
    * @returns The result from parsing data, if successful, older versions are migrated to the latest version
    */
   public safeParse(data: unknown): ParseResult<SchemaOf<M[LatestVer]>> {
-    const ver = this.getVersion(data);
+    const ver = this.getVersion(data)
 
     if (ver === null) {
-      return { type: "err", error: { type: "VER_CHECK_FAIL" } };
+      return { type: "err", error: { type: "VER_CHECK_FAIL" } }
     }
 
-    const verDef = this.versionMap[ver];
+    const verDef = this.versionMap[ver]
 
     if (!verDef) {
-      return { type: "err", error: { type: "INVALID_VER" } };
+      return { type: "err", error: { type: "INVALID_VER" } }
     }
 
-    const pass = verDef.schema.safeParse(data);
+    const pass = verDef.schema.safeParse(data)
 
     if (!pass.success) {
       return {
@@ -202,33 +198,33 @@ export class VersionedEntity<
           versionDef: verDef,
           error: pass.error,
         },
-      };
+      }
     }
 
-    let finalData = data;
+    let finalData = pass.data
 
     for (let up = ver + 1; up <= this.latestVersion; up++) {
-      const upDef = this.versionMap[up];
+      const upDef = this.versionMap[up]
 
       if (!upDef) {
         return {
           type: "err",
           error: { type: "BUG_NO_INTERMEDIATE_FOUND", missingVer: up },
-        };
+        }
       }
 
       if (upDef.initial) {
         return {
           type: "err",
           error: { type: "BUG_INTERMEDIATE_MARKED_INITIAL", ver: up },
-        };
+        }
       }
 
-      finalData = upDef.up(finalData);
+      finalData = upDef.up(finalData)
     }
 
     // @ts-expect-error - TypeScript cannot understand that the above loop will update finalData to the latest version
-    return { type: "ok", value: finalData };
+    return { type: "ok", value: finalData }
   }
 }
 
@@ -239,7 +235,7 @@ export class VersionedEntity<
 export type InferredEntity<Entity extends VersionedEntity<any, any>> =
   Entity extends VersionedEntity<infer LatestVer, infer VersionMap>
     ? SchemaOf<VersionMap[LatestVer]>
-    : never;
+    : never
 
 /**
  * Provides a union type of all the versions of an entity.
@@ -247,7 +243,7 @@ export type InferredEntity<Entity extends VersionedEntity<any, any>> =
 export type AllSchemasOfEntity<Entity extends VersionedEntity<any, any>> =
   Entity extends VersionedEntity<any, infer VersionMap>
     ? SchemaOf<VersionMap[keyof VersionMap]>
-    : never;
+    : never
 
 /**
  * Creates a Verzod Versioned entity
@@ -256,13 +252,13 @@ export type AllSchemasOfEntity<Entity extends VersionedEntity<any, any>> =
 export function createVersionedEntity<
   LatestVer extends number,
   VersionMap extends Record<LatestVer, Version<any, any>> &
-    Record<number | LatestVer, Version<any, any>>,
+    Record<number | LatestVer, Version<any, any>>
 >(def: {
-  versionMap: VersionMap;
-  latestVersion: LatestVer;
-  getVersion: (data: unknown) => number | null;
+  versionMap: VersionMap
+  latestVersion: LatestVer
+  getVersion: (data: unknown) => number | null
 }) {
-  return new VersionedEntity(def.versionMap, def.latestVersion, def.getVersion);
+  return new VersionedEntity(def.versionMap, def.latestVersion, def.getVersion)
 }
 
 /**
@@ -273,23 +269,21 @@ export function createVersionedEntity<
  *
  * NOTE: This assumes the schema has a floating (not dependent) version to the entity.
  */
-export function entityReference<Entity extends VersionedEntity<any, any>>(
-  entity: Entity,
-) {
+export function entityReference<Entity extends VersionedEntity<any, any>>(entity: Entity) {
   return z
     .custom<AllSchemasOfEntity<Entity>>((data) => {
-      return entity.is(data);
+      return entity.is(data)
     })
     .transform<InferredEntity<Entity>>((data) => {
-      const parseResult = entity.safeParse(data);
+      const parseResult = entity.safeParse(data)
 
       if (parseResult.type !== "ok") {
         // This should never happen unless you have a very weird/bad entity definition.
         throw new Error(
-          "Invalid entity definition. `entity.is` returned success, safeParse failed.",
-        );
+          "Invalid entity definition. `entity.is` returned success, safeParse failed."
+        )
       }
 
-      return parseResult.value as InferredEntity<Entity>;
-    });
+      return parseResult.value as InferredEntity<Entity>
+    })
 }


### PR DESCRIPTION
This fixes a bug with nested entity references where nested migrations would be dropped.

I think the easiest is to just check the added test case.

Without my fix my test example

```
{ 
   v: 1,
   c: 4,
   child: {
        v: 1,
        a: 8,
      }
}
```

would have been migrated to 

```
{ 
   v: 2,
   d: 4,
   child: {
        v: 1,
        a: 8,
      }
}
```

instead of


```
{ 
   v: 2,
   d: 4,
   child: {
        v: 2,
        b: 8,
      }
}
```


sorry for the noisy diff, I don't know which prettier config you use. Maybe you can format the PR?