### PR TITLE
fix: update return type of `entityReference` to remove type recursion error issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -270,7 +270,7 @@ export function createVersionedEntity<
  */
 export function entityReference<Entity extends VersionedEntity<any, any>>(entity: Entity) {
   return z
-    .custom<AllSchemasOfEntity<Entity>>((data) => {
+    .custom((data) => {
       return entity.is(data)
     })
     .transform<InferredEntity<Entity>>((data) => {


### PR DESCRIPTION
This PR intends to add a small tweak to update the (inferred) return type of `entityReference` function to avoid making the TypeScript compiler recurse across the types leading to type instantiation failing.

This PR is in response to the issue that was raised while implementing this PR: https://github.com/hoppscotch/hoppscotch/pull/4635, where the TypeScript compiler errored with the type excessively deep error.

The fix done here removes the redundant check which removes the expensive process of building up a validation result type for the custom validator step that leads to type instantiation having issues.
