### PR TITLE
Formally validate up() results to ensure invalid data is not waved through during migrations

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -992,14 +992,14 @@ describe("createVersionedEntity", () => {
       if (result.type === "ok") {
         // The root's migration function saw v1 children
         expect(rootChildVersions).toEqual([1, 1])
-        
-        // Final result: parent is migrated but children are not (up didn't migrate them)
+
+        // Final result: parent is migrated, and children are also migrated by the schema's entityRefUptoVersion transform
         expect(result.value.v).toBe(2)
         expect(result.value.name).toBe("root_v2")
-        expect(result.value.children[0].v).toBe(1)
-        expect(result.value.children[0].name).toBe("child1")
-        expect(result.value.children[1].v).toBe(1)
-        expect(result.value.children[1].name).toBe("child2")
+        expect(result.value.children[0].v).toBe(2)
+        expect(result.value.children[0].name).toBe("child1_v2")
+        expect(result.value.children[1].v).toBe(2)
+        expect(result.value.children[1].name).toBe("child2_v2")
       }
     })
   })
@@ -1088,12 +1088,12 @@ describe("createVersionedEntity", () => {
       if (result.type === "ok") {
         // Parent still sees v1 child during migration (even without z.lazy)
         expect(childMigrationVersion).toBe(1)
-        
-        // Final result: parent is migrated but child is not (up didn't migrate it)
+
+        // Final result: parent is migrated, and child is also migrated by the schema's entityRefUptoVersion transform
         expect(result.value.v).toBe(2)
         expect(result.value.name).toBe("parent_parent_v2")
-        expect(result.value.child.v).toBe(1)
-        expect(result.value.child.name).toBe("child")
+        expect(result.value.child.v).toBe(2)
+        expect(result.value.child.name).toBe("child_child_v2")
       }
     })
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,7 +266,23 @@ export class VersionedEntity<
         }
       }
 
-      finalData = upDef.up(finalData)
+      const nextData = upDef.up(finalData)
+
+      const nextDataParseResult = upDef.schema.safeParse(nextData)
+
+      if (!nextDataParseResult.success) {
+        return {
+          type: "err",
+          error: {
+            type: "GIVEN_VER_VALIDATION_FAIL",
+            version: up,
+            versionDef: upDef,
+            error: nextDataParseResult.error
+          }
+        }
+      }
+
+      finalData = nextDataParseResult.data
     }
 
     return { type: "ok", value: finalData }


### PR DESCRIPTION
verzod's `safeParse` method doesn't do any runtime checks to ensure that the `up()` method actually returns a valid object for the given version. 

This PR adds this check, so that if between versions an invalidity appears, it is caught and expressed as a safeParse failure.