### PR TITLE
Check version number in `isLatest()` (as in `is()`)

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -450,6 +450,133 @@ describe("createVersionedEntity", () => {
     })
   })
 
+  describe("isLatest", () => {
+    it("returns true when the data is of the latest version with correct shape", () => {
+      const entity = createTestEntity()
+
+      const data = {
+        name: "test",
+        v: 2,
+        variables: [
+          {
+            name: "test",
+            value: "test",
+            masked: false
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(true)
+    })
+
+    it("returns false when the shape is correct but the version number is wrong (v1 shape with v2 version)", () => {
+      const entity = createTestEntity()
+
+      // Data has v2 structure (correct shape) but wrong version number
+      const data = {
+        name: "test",
+        v: 1, // Wrong version - should be 2
+        variables: [
+          {
+            name: "test",
+            value: "test",
+            masked: false // This is v2 structure
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+
+    it("returns false when the shape is correct but the version number is wrong (v2 shape with v1 version)", () => {
+      const entity = createTestEntity()
+
+      // Data has v2 structure (correct shape) but wrong version number
+      const data = {
+        name: "test",
+        v: 1, // Wrong version - should be 2
+        variables: [
+          {
+            name: "test",
+            masked: true // This is v2 structure
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+
+    it("returns false when the shape is correct but the version number is invalid", () => {
+      const entity = createTestEntity()
+
+      // Data has v2 structure (correct shape) but invalid version number
+      const data = {
+        name: "test",
+        v: 3, // Invalid version - not in version map
+        variables: [
+          {
+            name: "test",
+            value: "test",
+            masked: false // This is v2 structure
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+
+    it("returns false when the data does not match the latest schema version", () => {
+      const entity = createTestEntity()
+
+      const data = {
+        name: "test",
+        v: 2,
+        variables: [
+          {
+            name: "test",
+            value: 1 // Invalid: should be string
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+
+    it("returns false when the data doesn't resolve to a version", () => {
+      const entity = createTestEntity()
+
+      const data = {
+        name: "test",
+        variables: [
+          {
+            name: "test",
+            value: "test",
+            masked: false
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+
+    it("returns false when the data is of an old version with correct old shape", () => {
+      const entity = createTestEntity()
+
+      const data = {
+        name: "test",
+        v: 1,
+        variables: [
+          {
+            name: "test",
+            value: "test"
+          }
+        ]
+      }
+
+      expect(entity.isLatest(data)).toEqual(false)
+    })
+  })
+
   describe("isUpToVersion", () => {
     it("returns true for data at exact version", () => {
       const entity = createTestEntity()

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export class VersionedEntity<
    * @returns Whether the given data is a valid entity of any version of the entity.
    */
   public is(data: unknown): data is SchemaOf<M[keyof M]> {
-    let ver = this.getVersion(data)
+    const ver = this.getVersion(data)
 
     if (ver === null) return false
 
@@ -172,7 +172,17 @@ export class VersionedEntity<
    * @returns Whether the given data is a valid entity of the latest version of the entity.
    */
   public isLatest(data: unknown): data is SchemaOf<M[LatestVer]> {
-    return this.versionMap[this.latestVersion].schema.safeParse(data).success
+    const ver = this.getVersion(data);
+
+    if (ver === null) return false;
+
+    if (ver !== this.latestVersion) return false;
+
+    const verDef = this.versionMap[ver];
+
+    if (!verDef) return false;
+
+    return verDef.schema.safeParse(data).success;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,17 +172,17 @@ export class VersionedEntity<
    * @returns Whether the given data is a valid entity of the latest version of the entity.
    */
   public isLatest(data: unknown): data is SchemaOf<M[LatestVer]> {
-    const ver = this.getVersion(data);
+    const ver = this.getVersion(data)
 
-    if (ver === null) return false;
+    if (ver === null) return false
 
-    if (ver !== this.latestVersion) return false;
+    if (ver !== this.latestVersion) return false
 
-    const verDef = this.versionMap[ver];
+    const verDef = this.versionMap[ver]
 
-    if (!verDef) return false;
+    if (!verDef) return false
 
-    return verDef.schema.safeParse(data).success;
+    return verDef.schema.safeParse(data).success
   }
 
   /**


### PR DESCRIPTION
Right now it's possible to trick isLatest into returning `true` if the shape is *roughly* correct, even if `getVersion` says otherwise — it simply doesn't check if the version it resolves to is, in fact, the latest version defined in the entity config.

This PR aligns `isLatest()` with `is()` by checking `getVersion()` for consistency. It also adds a suite of tests for `isLatest()`.